### PR TITLE
feat(ci): add pre-fanout breaking-change check

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -73,3 +73,38 @@ jobs:
         # referencing.Registry per lane so those cross-schema refs resolve.
         shell: bash
         run: python3 scripts/validate_examples.py
+
+  runtime-compat:
+    # Pre-fanout breaking-change check: validate that oesis-runtime's
+    # hand-coded validators still accept every contract example on this PR.
+    # If a schema change tightens a constraint runtime can't honor, this
+    # blocks the merge BEFORE release-fanout opens broken sync PRs across
+    # downstream repos.
+    #
+    # Failure here means: this PR would break runtime sync. Fix one of:
+    #   (a) update the runtime validator in a follow-up runtime PR first
+    #   (b) revisit the contract change to be backward-compatible
+    #   (c) document an explicit migration path before merging
+    #
+    # See CONSUMING.md "Pattern 1 — Runtime" for the validator-drift contract.
+    name: Runtime validators accept contract examples
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout contracts (PR branch)
+        uses: actions/checkout@v4
+        with:
+          path: contracts
+      - name: Checkout runtime (main)
+        uses: actions/checkout@v4
+        with:
+          repository: lumenaut-llc/oesis_runtime
+          ref: main
+          path: runtime
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Run pre-fanout compat check
+        working-directory: contracts
+        env:
+          RUNTIME_PATH: ${{ github.workspace }}/runtime
+        run: python3 scripts/check_runtime_compat.py

--- a/CONSUMING.md
+++ b/CONSUMING.md
@@ -75,7 +75,12 @@ Trade-off chosen by the project:
 - **Pro**: tailored error messages, domain-specific constraints beyond schema, no runtime jsonschema dependency
 - **Con**: validator drift risk — hand-coded validator must stay in sync with JSON Schema
 
-Drift risk is mitigated at CI time: `scripts/validate_examples.py` in this repo validates every example against its schema using `jsonschema`. If a hand-coded validator in runtime accepts something the schema rejects, the example eventually fails CI.
+Drift risk is mitigated at CI time on **two** axes:
+
+- **Schema-against-example** — `scripts/validate_examples.py` in this repo validates every example against its schema using `jsonschema`. If a hand-coded validator in runtime accepts something the schema rejects, the example fails CI.
+- **Pre-fanout runtime-compat** — `scripts/check_runtime_compat.py` clones `oesis-runtime` in CI and runs runtime's hand-coded validators against every contract example on the PR branch. This blocks the merge **before** `release-fanout.yml` opens broken sync PRs across all downstream repos. Run locally with `RUNTIME_PATH=../oesis-runtime python3 scripts/check_runtime_compat.py`.
+
+Together these catch drift in both directions: the schema-only check catches "runtime accepts payloads the schema would reject"; the runtime-compat check catches "schema accepts payloads runtime would reject."
 
 ### Adding a new runtime consumer
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,10 +45,36 @@ Before submitting, run at minimum:
 # Syntax check all JSON files
 find . -name "*.json" -exec python3 -m json.tool {} \; >/dev/null
 
+# Schema-against-example validation (this repo)
+python3 scripts/validate_examples.py
+
+# Pre-fanout breaking-change check — confirms runtime's hand-coded
+# validators still accept every contract example. This is the same gate
+# that runs in CI; running it locally avoids waiting on CI to learn
+# you've broken the runtime sync contract.
+RUNTIME_PATH=../oesis-runtime python3 scripts/check_runtime_compat.py
+
 # Full cross-repo consistency check (from oesis-program-specs)
 cd ../oesis-program-specs
 make cross-repo-sync
 ```
+
+### What the runtime-compat check catches
+
+The `check_runtime_compat.py` script imports `oesis-runtime`'s hand-coded
+validators (e.g. `validate_node_observation`, `validate_trust_score`) and runs
+them against every contract example on the PR branch. If a schema change tightens
+a constraint the runtime validator can't yet honor, this fails — **before**
+`release-fanout.yml` opens broken sync PRs in oesis-runtime, oesis-public-site,
+oesis-hardware, and oesis-program-specs.
+
+When this check fails, fix one of:
+
+- (a) Land the matching runtime validator update in a runtime PR first
+- (b) Revisit the contract change to be backward-compatible
+- (c) Document a migration path in `<lane>/schema-migration-*.md` before merging
+
+See [CONSUMING.md](CONSUMING.md) Pattern 1 for the validator-drift contract.
 
 ## Commit style
 

--- a/scripts/check_runtime_compat.py
+++ b/scripts/check_runtime_compat.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""
+Pre-fanout breaking-change check.
+
+Before contract changes merge to oesis-contracts/main and trigger
+release-fanout, validate that oesis-runtime's hand-coded validators
+will still accept every contract example. If a schema change tightens
+a constraint that runtime can't yet honor (or vice versa), this catches
+it at the contracts PR — not after fanout opens broken sync PRs in
+every downstream repo.
+
+Strategy:
+- Discover every example under oesis-contracts/v*/examples/
+- For each example, derive the runtime validator function name:
+    <basename-with-hyphens-replaced>.example.json -> validate_<name>
+  Variant examples (e.g. intervention-event-flood.example.json) collapse
+  to the base type (validate_intervention_event) — they exercise the same
+  validator with a different payload shape.
+- Import the matching runtime lane's validate_examples module and call
+  the validator with the contract example payload.
+- Report pass/fail per example. Exit 1 if any fail.
+
+Lane mapping (contracts lane -> runtime module):
+  v0.1 -> oesis.ingest.v0_1.validate_examples
+  v1.0 -> oesis.ingest.v1_0.validate_examples (inherits v0.1 validators)
+  v1.5 -> oesis.ingest.v1_0.validate_examples (no v1_5 module yet; gap G18)
+
+Usage:
+  RUNTIME_PATH=/path/to/oesis-runtime python3 scripts/check_runtime_compat.py
+  # or:
+  python3 scripts/check_runtime_compat.py --runtime /path/to/oesis-runtime
+
+Designed to run in the oesis-contracts CI after cloning runtime into a
+sibling directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Callable
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Each contracts lane maps to a runtime ingest lane module. v1.5 falls back
+# to the v1.0 runtime validators because no v1_5 ingest module exists yet
+# (tracked as gap G18 in oesis-runtime).
+LANE_TO_RUNTIME_MODULE = {
+    "v0.1": "oesis.ingest.v0_1.validate_examples",
+    "v1.0": "oesis.ingest.v1_0.validate_examples",
+    "v1.5": "oesis.ingest.v1_0.validate_examples",
+}
+
+# Explicit routing for variant examples whose basename doesn't naively map
+# to the right validator. Format: example basename -> base type to validate as.
+# Use cases:
+#   - Different schema entirely (node-observation-flood is actually a flood-node packet)
+#   - Variant payloads of same schema (node-observation-mast-lite still bench-air)
+EXPLICIT_VARIANT_ROUTING = {
+    # node-observation-flood uses oesis.flood-node.v1 schema, not bench-air;
+    # it duplicates flood-observation.example.json's validator coverage.
+    "node-observation-flood": "flood-observation",
+    # node-observation-mast-lite is a bench-air variant payload.
+    "node-observation-mast-lite": "node-observation",
+}
+
+# Variant examples (e.g. intervention-event-flood) reuse the base validator.
+# Map a variant suffix that should NOT be stripped to itself; everything else
+# falls through to the longest-match strip-from-end logic.
+KNOWN_BASE_TYPES = {
+    "node-observation",
+    "normalized-observation",
+    "intervention-event",
+    "verification-outcome",
+    "circuit-monitor-observation",
+    "normalized-circuit-observation",
+    "weather-pm-observation",
+    "normalized-weather-pm-observation",
+    "flood-observation",
+    "normalized-flood-observation",
+    "consent-record",
+    "consent-store",
+    "control-compatibility",
+    "deployment-metadata",
+    "equipment-state-observation",
+    "evidence-summary",
+    "export-bundle",
+    "house-capability",
+    "house-state",
+    "network-assist-signal",
+    "node-registry",
+    "operator-access-event",
+    "parcel-context",
+    "parcel-state",
+    "public-context",
+    "raw-public-smoke",
+    "raw-public-weather",
+    "research-data-export",
+    "retention-cleanup-report",
+    "rights-request",
+    "rights-request-store",
+    "shared-neighborhood-signal",
+    "sharing-settings",
+    "sharing-store",
+    "source-provenance-record",
+    "trust-score",
+}
+
+
+def base_type_for(example_basename: str) -> str:
+    """
+    Collapse a variant example basename to its base type.
+
+    e.g. 'intervention-event-flood' -> 'intervention-event'
+         'node-observation' -> 'node-observation'
+         'node-observation-flood' -> 'flood-observation' (via explicit override)
+
+    Strategy: explicit overrides win, then longest known base type that is a prefix.
+    """
+    if example_basename in EXPLICIT_VARIANT_ROUTING:
+        return EXPLICIT_VARIANT_ROUTING[example_basename]
+    for candidate in sorted(KNOWN_BASE_TYPES, key=len, reverse=True):
+        if example_basename == candidate or example_basename.startswith(candidate + "-"):
+            return candidate
+    # Fall back to the basename itself; runtime will report "no validator" if missing.
+    return example_basename
+
+
+def validator_func_name(base_type: str) -> str:
+    return "validate_" + base_type.replace("-", "_")
+
+
+def load_runtime_module(module_path: str):
+    return importlib.import_module(module_path)
+
+
+def discover_examples(lane: str) -> list[Path]:
+    examples_dir = REPO_ROOT / lane / "examples"
+    if not examples_dir.is_dir():
+        return []
+    return sorted(examples_dir.glob("*.example.json"))
+
+
+def check_lane(lane: str, runtime_module_path: str) -> list[str]:
+    """Return list of failure messages for this lane."""
+    failures: list[str] = []
+    try:
+        module = load_runtime_module(runtime_module_path)
+    except ImportError as exc:
+        return [f"[{lane}] cannot import {runtime_module_path}: {exc}"]
+
+    for example_path in discover_examples(lane):
+        basename = example_path.name[: -len(".example.json")]
+        base_type = base_type_for(basename)
+        func_name = validator_func_name(base_type)
+        validator: Callable | None = getattr(module, func_name, None)
+
+        if validator is None:
+            # Runtime hasn't implemented this validator yet. Not a regression
+            # caused by this PR — flag as info, don't fail.
+            print(f"SKIP [{lane}] {basename}: no {func_name} in {runtime_module_path}")
+            continue
+
+        try:
+            payload = json.loads(example_path.read_text(encoding="utf-8"))
+            validator(payload)
+            print(f"PASS [{lane}] {basename}")
+        except Exception as exc:  # ValidationError or KeyError or unexpected
+            rel = example_path.relative_to(REPO_ROOT)
+            msg = f"FAIL [{lane}] {rel} via {func_name}: {exc}"
+            failures.append(msg)
+            print(msg, file=sys.stderr)
+
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--runtime",
+        default=os.environ.get("RUNTIME_PATH"),
+        help="Path to oesis-runtime checkout (or set RUNTIME_PATH env var)",
+    )
+    args = parser.parse_args()
+
+    if not args.runtime:
+        print(
+            "ERROR: --runtime <path> or RUNTIME_PATH env var required",
+            file=sys.stderr,
+        )
+        return 2
+
+    runtime_path = Path(args.runtime).expanduser().resolve()
+    if not (runtime_path / "oesis").is_dir():
+        print(
+            f"ERROR: {runtime_path} does not look like an oesis-runtime checkout "
+            "(no oesis/ package found)",
+            file=sys.stderr,
+        )
+        return 2
+
+    sys.path.insert(0, str(runtime_path))
+
+    all_failures: list[str] = []
+    for lane, runtime_module in LANE_TO_RUNTIME_MODULE.items():
+        all_failures.extend(check_lane(lane, runtime_module))
+
+    if all_failures:
+        print(
+            f"\n{len(all_failures)} contract example(s) rejected by runtime "
+            "validators. This PR would break downstream runtime sync.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("\nAll contract examples accepted by runtime validators.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Adds a CI gate that runs `oesis-runtime`'s hand-coded validators against every contract example on the PR branch. Catches schema regressions **before** `release-fanout.yml` opens broken sync PRs across all four downstream repos.

Closes #7. Closes audit weakness #8 (single point of failure where contract changes could merge freely without validating downstream impact).

## What's in the PR

- **`scripts/check_runtime_compat.py`** — driver script. Discovers contract examples per lane (v0.1, v1.0, v1.5), derives the runtime validator function name from each example's basename (with explicit overrides for variant filenames), invokes the validator with the example payload, reports pass/fail.
- **`.github/workflows/validate.yml`** — new `runtime-compat` job: checks out `oesis_runtime` main alongside contracts, runs the check.
- **`CONSUMING.md`** — Pattern 1 section documents the two-axis drift protection (schema-against-example + pre-fanout runtime-compat).
- **`CONTRIBUTING.md`** — Validation section adds the local-run command.

## Design decisions

- **Skip-don't-fail when runtime validator missing.** Examples like `trust-score`, `deployment-metadata`, `network-assist-signal`, `research-data-export` exist in v1.0 contracts but have no validator in `oesis.ingest.v1_0.validate_examples`. That's a runtime implementation gap, not a contract regression — script logs SKIP and moves on.
- **Variant routing override.** `node-observation-flood.example.json` would naively route to `validate_node_observation` (bench-air schema), but it's actually a `oesis.flood-node.v1` payload that should be validated by `validate_flood_observation`. An explicit `EXPLICIT_VARIANT_ROUTING` dict handles these cases. Adding new variants is a one-line addition.
- **v1.5 falls back to v1.0 runtime.** No `oesis.ingest.v1_5.validate_examples` exists yet (gap G18). v1.5 examples are checked against v1.0 validators which inherit v0.1 validators — the same coverage runtime currently provides for v1.5 fixtures.

## Local results (pre-PR)

```
PASS [v0.1] x 30
PASS [v1.0] x 13, SKIP x 4 (no validator yet)
PASS [v1.5] x 6
All contract examples accepted by runtime validators.
```

## Test plan

- [ ] CI `runtime-compat` job runs and passes on this PR (no schema changes here, so it should be green)
- [ ] Existing CI jobs still green
- [ ] Local `RUNTIME_PATH=../oesis-runtime python3 scripts/check_runtime_compat.py` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)