### PR TITLE
chore(bundle): regenerate contracts-bundle from v0.1 source

### DIFF
--- a/bundles/contracts-bundle/examples/parcel-context.example.json
+++ b/bundles/contracts-bundle/examples/parcel-context.example.json
@@ -21,8 +21,54 @@
     }
   ],
   "parcel_priors": {
-    "heat_retention_class": "moderate",
+    "heat_retention_class": "high",
     "runoff_tendency_class": "low",
-    "smoke_exposure_class": "moderate"
+    "smoke_exposure_class": "high",
+    "fema_zone": "AE",
+    "foundation_type": "basement",
+    "first_floor_elev_ft": 9.5,
+    "base_flood_elev_ft": 10.0,
+    "year_built": 1968,
+    "dist_to_water_ft": 420,
+    "zone_zero_clearance_class": "combustible",
+    "defensible_space_class": "partial",
+    "roof_class": "roof_class_a",
+    "exterior_class": "exterior_wood",
+    "vent_class": "vents_unscreened",
+    "window_class": "single_pane",
+    "dist_to_wildland_ft": 680
+  },
+  "structure_response_profile": {
+    "orientation_class": "southwest_exposed",
+    "hvac_type": "forced_air",
+    "filter_path_class": "1_inch_return",
+    "higher_merv_support": "unknown"
+  },
+  "site_dependency_profile": {
+    "drainage_path_notes": [
+      "driveway lip drains toward curb cut"
+    ],
+    "primary_route_posture": "limited_exits",
+    "backup_power_available": "yes"
+  },
+  "known_protective_capabilities": {
+    "recirculation_available": true,
+    "portable_purifier_present": true,
+    "motorized_shades_present": false,
+    "backup_power_present": true
+  },
+  "known_vulnerable_zones": [
+    "west upstairs bedroom",
+    "driveway low point"
+  ],
+  "divergence_tracking": {
+    "temperature_c": {
+      "persistence_minutes": 105,
+      "num_concordant_sensors": 2
+    },
+    "pm25": {
+      "persistence_minutes": 190,
+      "num_concordant_sensors": 2
+    }
   }
 }

--- a/bundles/contracts-bundle/examples/parcel-state.example.json
+++ b/bundles/contracts-bundle/examples/parcel-state.example.json
@@ -1,27 +1,29 @@
 {
-  "parcel_id": "parcel_123",
+  "parcel_id": "parcel_demo_001",
   "computed_at": "2026-03-30T19:46:00Z",
   "shelter_status": "unknown",
   "reentry_status": "unknown",
   "egress_status": "unknown",
   "asset_risk_status": "unknown",
-  "confidence": 0.30,
-  "evidence_mode": "insufficient",
-  "inference_basis": "insufficient",
+  "confidence": 0.69,
+  "evidence_mode": "local_plus_public",
+  "inference_basis": "local_plus_public",
   "explanation_payload": {
-    "headline": "Estimate uses limited local evidence with low parcel certainty.",
+    "headline": "Estimate uses local plus public evidence with medium confidence.",
     "basis": {
-      "evidence_mode": "insufficient",
-      "inference_basis": "insufficient",
-      "confidence_band": "low"
+      "evidence_mode": "local_plus_public",
+      "inference_basis": "local_plus_public",
+      "confidence_band": "medium"
     },
     "drivers": [
-      "Indoor gas-resistance trend shows a moderate change."
+      "Local temperature_c diverged from demo_regional_weather_v1 by 7.6 (local_depressed, sustained).",
+      "Regional conditions suggest modest heat concern.",
+      "Regional smoke context suggests modest smoke concern."
     ],
     "limitations": [
-      "The local node is indoor and does not represent parcel-wide outdoor conditions.",
-      "Parcel installation context is missing, so siting relevance and parcel priors cannot improve interpretation.",
-      "Confidence is limited because the current estimate relies on sparse or weakly representative evidence."
+      "Current local evidence comes from an indoor node and does not directly represent parcel-wide outdoor conditions.",
+      "Regional or neighborhood heat context is stronger than the local node reading, so parcel heat interpretation remains cautious.",
+      "Install role reference_indoor constrains how strongly this node represents wider parcel conditions."
     ],
     "evidence_contributions": [
       {
@@ -29,7 +31,7 @@
         "source_class": "local",
         "source_name": "bench-air-01",
         "role": "driver",
-        "summary": "Indoor gas-resistance trend shows a moderate change.",
+        "summary": "Local gas-resistance trend shows a moderate change, but it is not a direct smoke concentration measurement.",
         "hazards": [
           "smoke"
         ],
@@ -51,65 +53,438 @@
         "visibility": "dwelling_safe"
       },
       {
-        "contribution_id": "missing_parcel_context",
-        "source_class": "system",
-        "source_name": "parcel_123",
-        "role": "limitation",
-        "summary": "Parcel installation context is missing, so siting relevance and parcel priors cannot improve interpretation.",
+        "contribution_id": "parcel_heat_prior",
+        "source_class": "parcel_context",
+        "source_name": "parcel_demo_001",
+        "role": "driver",
+        "summary": "Parcel metadata applies a +0.04 heat prior from retention class 'high'.",
         "hazards": [
-          "smoke",
-          "heat",
-          "flood"
+          "heat"
         ],
-        "weight": 0.64,
+        "weight": 0.12,
         "visibility": "dwelling_safe"
       },
       {
-        "contribution_id": "missing_flood_evidence",
-        "source_class": "local",
-        "source_name": "bench-air-01",
-        "role": "limitation",
-        "summary": "No flood-capable local sensor or public flood context is present.",
+        "contribution_id": "parcel_smoke_prior",
+        "source_class": "parcel_context",
+        "source_name": "parcel_demo_001",
+        "role": "driver",
+        "summary": "Parcel metadata sets a smoke prior at 0.30 from exposure class 'high'.",
         "hazards": [
-          "flood"
+          "smoke"
         ],
-        "weight": 0.58,
+        "weight": 0.24,
         "visibility": "dwelling_safe"
       },
       {
-        "contribution_id": "low_confidence_gate",
-        "source_class": "system",
-        "source_name": "confidence_gate",
-        "role": "limitation",
-        "summary": "Confidence is limited because the current estimate relies on sparse or weakly representative evidence.",
+        "contribution_id": "parcel_flood_prior",
+        "source_class": "parcel_context",
+        "source_name": "parcel_demo_001",
+        "role": "driver",
+        "summary": "Parcel flood prior resolves to 0.026 from FEMA zone 'AE' and parcel modifiers.",
         "hazards": [
-          "smoke",
+          "flood"
+        ],
+        "weight": 0.29,
+        "visibility": "dwelling_safe"
+      },
+      {
+        "contribution_id": "divergence_temperature_c",
+        "source_class": "system",
+        "source_name": "demo_regional_weather_v1",
+        "role": "driver",
+        "summary": "Local temperature_c diverged from demo_regional_weather_v1 by 7.6 (local_depressed, sustained).",
+        "hazards": [
+          "heat"
+        ],
+        "weight": 0.53,
+        "visibility": "dwelling_safe"
+      },
+      {
+        "contribution_id": "divergence_pm25",
+        "source_class": "system",
+        "source_name": "demo_regional_smoke_v1",
+        "role": "driver",
+        "summary": "Local pm25 diverged from demo_regional_smoke_v1 by 19.8 (local_depressed, persistent).",
+        "hazards": [
+          "smoke"
+        ],
+        "weight": 0.42,
+        "visibility": "dwelling_safe"
+      },
+      {
+        "contribution_id": "public_demo_regional_weather_v1",
+        "source_class": "public",
+        "source_name": "demo_regional_weather_v1",
+        "role": "driver",
+        "summary": "Regional conditions suggest modest heat concern.",
+        "hazards": [
           "heat",
           "flood"
         ],
-        "weight": 0.68,
-        "visibility": "dwelling_safe"
+        "weight": 0.48,
+        "visibility": "dwelling_safe",
+        "freshness_band": "fresh"
+      },
+      {
+        "contribution_id": "public_demo_regional_smoke_v1",
+        "source_class": "public",
+        "source_name": "demo_regional_smoke_v1",
+        "role": "driver",
+        "summary": "Regional smoke context suggests modest smoke concern.",
+        "hazards": [
+          "smoke",
+          "flood"
+        ],
+        "weight": 0.48,
+        "visibility": "dwelling_safe",
+        "freshness_band": "fresh"
       }
     ],
     "source_breakdown": {
       "local": true,
       "shared": false,
-      "public": false,
-      "parcel_context": false,
+      "public": true,
+      "parcel_context": true,
       "system": true
-    }
+    },
+    "support_objects_present": [
+      "house_state",
+      "house_capability",
+      "intervention_event",
+      "verification_outcome"
+    ],
+    "divergence_summary": [
+      "Public data alone would have classified smoke as 'safe' (p=0.31), while fused parcel inference classified it as 'safe' (p=0.37). Local evidence diverged by 19.8 and was local_depressed relative to the regional baseline.",
+      "Public data alone would have classified heat as 'safe' (p=0.31), while fused parcel inference classified it as 'safe' (p=0.31). Local evidence diverged by 7.6 and was local_depressed relative to the regional baseline."
+    ],
+    "top_divergence_records": [
+      {
+        "timestamp": "2026-03-30T19:45:00Z",
+        "sensor_id": "bench-air-01",
+        "parameter": "temperature_c",
+        "local_value": 23.4,
+        "regional_value": 31.0,
+        "regional_source": "demo_regional_weather_v1",
+        "correction_applied": "none",
+        "abs_diff": 7.6,
+        "ratio": 0.75,
+        "z_score": 3.45,
+        "direction": "local_depressed",
+        "magnitude": "extreme",
+        "persistence_minutes": 105,
+        "persistence_class": "sustained",
+        "aqi_category_local": null,
+        "aqi_category_regional": null,
+        "aqi_category_diff": null,
+        "num_concordant_sensors": 2,
+        "confidence": "high"
+      },
+      {
+        "timestamp": "2026-03-30T19:45:00Z",
+        "sensor_id": "indoor-response-01",
+        "parameter": "pm25",
+        "local_value": 18.2,
+        "regional_value": 38.0,
+        "regional_source": "demo_regional_smoke_v1",
+        "correction_applied": "none",
+        "abs_diff": 19.8,
+        "ratio": 0.48,
+        "z_score": 2.48,
+        "direction": "local_depressed",
+        "magnitude": "moderate",
+        "persistence_minutes": 190,
+        "persistence_class": "persistent",
+        "aqi_category_local": "moderate",
+        "aqi_category_regional": "usg",
+        "aqi_category_diff": -1,
+        "num_concordant_sensors": 2,
+        "confidence": "medium"
+      }
+    ]
   },
   "reasons": [
     "Local gas-resistance trend shows a moderate change, but it is not a direct smoke concentration measurement.",
     "Current local evidence comes from an indoor node and does not directly represent parcel-wide outdoor conditions.",
-    "No flood-capable local sensor or public flood context is present, so flood-related outputs remain unknown.",
-    "Confidence is limited because the current decision uses sparse single-node evidence."
+    "Parcel metadata applies a +0.04 heat prior from retention class 'high'.",
+    "Parcel metadata sets a smoke prior at 0.30 from exposure class 'high'.",
+    "Parcel flood prior resolves to 0.026 from FEMA zone 'AE' and parcel modifiers.",
+    "Confidence improves because public context supports the local evidence, but parcel certainty is still limited.",
+    "Public data alone would have classified smoke as 'safe' (p=0.31), while fused parcel inference classified it as 'safe' (p=0.37). Local evidence diverged by 19.8 and was local_depressed relative to the regional baseline."
   ],
   "hazards": {
-    "smoke_probability": 0.12,
-    "flood_probability": 0.00,
-    "heat_probability": 0.02
+    "smoke_probability": 0.37,
+    "flood_probability": 0.03,
+    "heat_probability": 0.31
   },
+  "hazard_statuses": {
+    "smoke": "safe",
+    "flood": "unknown",
+    "heat": "safe"
+  },
+  "parcel_priors_applied": {
+    "smoke": {
+      "probability": 0.3,
+      "adjustment": 0.12,
+      "summary": "Parcel metadata sets a smoke prior at 0.30 from exposure class 'high'.",
+      "factors": [
+        {
+          "factor": "smoke_exposure_class",
+          "value": "high",
+          "effect": "baseline_probability",
+          "applied_value": 0.12
+        },
+        {
+          "factor": "zone_zero_clearance_class",
+          "value": "combustible",
+          "effect": "multiplier",
+          "applied_value": 1.8
+        },
+        {
+          "factor": "roof_class",
+          "value": "roof_class_a",
+          "effect": "multiplier",
+          "applied_value": 0.7
+        }
+      ]
+    },
+    "heat": {
+      "probability": null,
+      "adjustment": 0.04,
+      "summary": "Parcel metadata applies a +0.04 heat prior from retention class 'high'.",
+      "factors": [
+        {
+          "factor": "heat_retention_class",
+          "value": "high",
+          "effect": "adjustment",
+          "applied_value": 0.04
+        }
+      ]
+    },
+    "flood": {
+      "probability": 0.0263,
+      "adjustment": null,
+      "summary": "Parcel flood prior resolves to 0.026 from FEMA zone 'AE' and parcel modifiers.",
+      "factors": [
+        {
+          "factor": "fema_zone",
+          "value": "AE",
+          "effect": "baseline_probability",
+          "applied_value": 0.01
+        },
+        {
+          "factor": "foundation_type",
+          "value": "basement",
+          "effect": "multiplier",
+          "applied_value": 1.3
+        },
+        {
+          "factor": "dist_to_water_ft",
+          "value": 420,
+          "effect": "multiplier",
+          "applied_value": 1.5
+        }
+      ]
+    }
+  },
+  "divergence_records": [
+    {
+      "timestamp": "2026-03-30T19:45:00Z",
+      "sensor_id": "bench-air-01",
+      "parameter": "temperature_c",
+      "local_value": 23.4,
+      "regional_value": 31.0,
+      "regional_source": "demo_regional_weather_v1",
+      "correction_applied": "none",
+      "abs_diff": 7.6,
+      "ratio": 0.75,
+      "z_score": 3.45,
+      "direction": "local_depressed",
+      "magnitude": "extreme",
+      "persistence_minutes": 105,
+      "persistence_class": "sustained",
+      "aqi_category_local": null,
+      "aqi_category_regional": null,
+      "aqi_category_diff": null,
+      "num_concordant_sensors": 2,
+      "confidence": "high"
+    },
+    {
+      "timestamp": "2026-03-30T19:45:00Z",
+      "sensor_id": "indoor-response-01",
+      "parameter": "pm25",
+      "local_value": 18.2,
+      "regional_value": 38.0,
+      "regional_source": "demo_regional_smoke_v1",
+      "correction_applied": "none",
+      "abs_diff": 19.8,
+      "ratio": 0.48,
+      "z_score": 2.48,
+      "direction": "local_depressed",
+      "magnitude": "moderate",
+      "persistence_minutes": 190,
+      "persistence_class": "persistent",
+      "aqi_category_local": "moderate",
+      "aqi_category_regional": "usg",
+      "aqi_category_diff": -1,
+      "num_concordant_sensors": 2,
+      "confidence": "medium"
+    }
+  ],
+  "public_only_counterfactual": {
+    "hazards": {
+      "smoke_probability": 0.31,
+      "flood_probability": 0.03,
+      "heat_probability": 0.31
+    },
+    "hazard_statuses": {
+      "smoke": "safe",
+      "flood": "unknown",
+      "heat": "safe"
+    },
+    "confidence": 0.66
+  },
+  "closed_loop_summary": {
+    "hazard_type": "smoke",
+    "status": "not_attempted",
+    "summary": "No smoke-response loop has been attempted yet.",
+    "loop_completion_metrics": {
+      "total_loops_triggered": 0,
+      "loops_with_verified_outcomes": 0,
+      "completion_ratio": 0.0,
+      "by_hazard": {
+        "smoke": {
+          "loops_triggered": 0,
+          "loops_verified": 0,
+          "completion_ratio": 0.0
+        },
+        "flood": {
+          "loops_triggered": 0,
+          "loops_verified": 0,
+          "completion_ratio": 0.0
+        },
+        "heat": {
+          "loops_triggered": 0,
+          "loops_verified": 0,
+          "completion_ratio": 0.0
+        }
+      }
+    },
+    "action_logs": [],
+    "outcome_records": []
+  },
+  "action_logs": [],
+  "outcome_records": [],
+  "contrastive_explanations": [
+    {
+      "explanation_id": "obs_example_0001:smoke:contrast",
+      "timestamp": "2026-03-30T19:46:00Z",
+      "hazard_type": "smoke",
+      "fact": {
+        "conclusion": "safe",
+        "hazard_level": "safe",
+        "probability": 0.37,
+        "confidence": 0.69,
+        "data_sources": [
+          "local:bench-air-01",
+          "local:house_state",
+          "parcel_context",
+          "parcel_capability",
+          "public:demo_regional_weather_v1",
+          "public:demo_regional_smoke_v1"
+        ]
+      },
+      "foil": {
+        "conclusion": "safe",
+        "hazard_level": "safe",
+        "probability": 0.31,
+        "confidence": 0.66,
+        "data_sources": [
+          "parcel_context",
+          "parcel_capability",
+          "public:demo_regional_weather_v1",
+          "public:demo_regional_smoke_v1"
+        ]
+      },
+      "contrast": {
+        "summary": "Public data alone would have classified smoke as 'safe' (p=0.31), while fused parcel inference classified it as 'safe' (p=0.37). Local evidence diverged by 19.8 and was local_depressed relative to the regional baseline.",
+        "delta_hazard_level": 0,
+        "delta_probability": 0.06,
+        "divergence_factors": [
+          {
+            "factor": "pm25",
+            "local_value": 18.2,
+            "public_value": 38.0,
+            "contribution_delta": 0.06,
+            "is_novel_signal": false
+          }
+        ]
+      },
+      "verification": {
+        "prediction_window_end": "2026-03-30T23:46:00Z",
+        "ground_truth_available": false,
+        "scores": {
+          "brier_score_fact": null,
+          "brier_score_foil": null,
+          "local_data_added_value": null
+        }
+      }
+    },
+    {
+      "explanation_id": "obs_example_0001:heat:contrast",
+      "timestamp": "2026-03-30T19:46:00Z",
+      "hazard_type": "heat",
+      "fact": {
+        "conclusion": "safe",
+        "hazard_level": "safe",
+        "probability": 0.31,
+        "confidence": 0.69,
+        "data_sources": [
+          "local:bench-air-01",
+          "local:house_state",
+          "parcel_context",
+          "parcel_capability",
+          "public:demo_regional_weather_v1",
+          "public:demo_regional_smoke_v1"
+        ]
+      },
+      "foil": {
+        "conclusion": "safe",
+        "hazard_level": "safe",
+        "probability": 0.31,
+        "confidence": 0.66,
+        "data_sources": [
+          "parcel_context",
+          "parcel_capability",
+          "public:demo_regional_weather_v1",
+          "public:demo_regional_smoke_v1"
+        ]
+      },
+      "contrast": {
+        "summary": "Public data alone would have classified heat as 'safe' (p=0.31), while fused parcel inference classified it as 'safe' (p=0.31). Local evidence diverged by 7.6 and was local_depressed relative to the regional baseline.",
+        "delta_hazard_level": 0,
+        "delta_probability": 0.0,
+        "divergence_factors": [
+          {
+            "factor": "temperature_c",
+            "local_value": 23.4,
+            "public_value": 31.0,
+            "contribution_delta": 0.0,
+            "is_novel_signal": true
+          }
+        ]
+      },
+      "verification": {
+        "prediction_window_end": "2026-03-31T01:46:00Z",
+        "ground_truth_available": false,
+        "scores": {
+          "brier_score_fact": null,
+          "brier_score_foil": null,
+          "local_data_added_value": null
+        }
+      }
+    }
+  ],
   "freshness": {
     "latest_observation_at": "2026-03-30T19:45:00Z",
     "seconds_since_latest": 60,
@@ -118,10 +493,18 @@
   "provenance_summary": {
     "observation_count": 1,
     "source_modes": [
-      "dwelling_node"
+      "dwelling_node",
+      "public_context",
+      "private_support_object"
     ],
     "observation_refs": [
       "obs_example_0001"
+    ],
+    "support_object_refs": [
+      "house_state",
+      "house_capability",
+      "intervention_event",
+      "verification_outcome"
     ]
   }
 }

--- a/bundles/contracts-bundle/manifest.json
+++ b/bundles/contracts-bundle/manifest.json
@@ -36,7 +36,7 @@
     "verification-outcome-flood": "examples/verification-outcome-flood.example.json",
     "verification-outcome-heat": "examples/verification-outcome-heat.example.json"
   },
-  "generated_at": "2026-04-24T00:00:00Z",
+  "generated_at": "2026-04-27T02:41:56Z",
   "lane": "v0.1",
   "schema_version_set": [
     "oesis.bench-air.v1"
@@ -69,7 +69,7 @@
     "source-provenance-record": "schemas/source-provenance-record.schema.json",
     "verification-outcome": "schemas/verification-outcome.schema.json"
   },
-  "source_commit": "46277162a9688f6e76ed004f8d4e3336cb5a896c",
+  "source_commit": "a3ec2d9fccdc92e66c85763b2f9696768d91d10f",
   "source_repo": "oesis-contracts",
   "source_roots": {
     "examples": [

--- a/bundles/contracts-bundle/schemas/node-observation.schema.json
+++ b/bundles/contracts-bundle/schemas/node-observation.schema.json
@@ -71,6 +71,28 @@
         }
       }
     },
+    "sequence": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "transport": {
+      "type": "object"
+    },
+    "notes": {
+      "type": "string"
+    },
+    "install_role": {
+      "type": "string",
+      "minLength": 1
+    },
+    "privacy_mode": {
+      "type": "string",
+      "enum": [
+        "normal",
+        "derived_only",
+        "bounded_internal"
+      ]
+    },
     "health": {
       "type": "object",
       "required": [

--- a/bundles/contracts-bundle/schemas/parcel-state.schema.json
+++ b/bundles/contracts-bundle/schemas/parcel-state.schema.json
@@ -16,6 +16,11 @@
     "explanation_payload",
     "reasons",
     "hazards",
+    "hazard_statuses",
+    "parcel_priors_applied",
+    "divergence_records",
+    "public_only_counterfactual",
+    "contrastive_explanations",
     "freshness",
     "provenance_summary"
   ],
@@ -42,9 +47,7 @@
       "$ref": "#/$defs/status"
     },
     "confidence": {
-      "type": "number",
-      "minimum": 0,
-      "maximum": 1
+      "$ref": "#/$defs/probability"
     },
     "evidence_mode": {
       "type": "string",
@@ -134,82 +137,7 @@
         "evidence_contributions": {
           "type": "array",
           "items": {
-            "type": "object",
-            "required": [
-              "contribution_id",
-              "source_class",
-              "source_name",
-              "role",
-              "summary",
-              "hazards",
-              "weight",
-              "visibility"
-            ],
-            "additionalProperties": false,
-            "properties": {
-              "contribution_id": {
-                "type": "string",
-                "minLength": 1
-              },
-              "source_class": {
-                "type": "string",
-                "enum": [
-                  "local",
-                  "shared",
-                  "public",
-                  "parcel_context",
-                  "system"
-                ]
-              },
-              "source_name": {
-                "type": "string",
-                "minLength": 1
-              },
-              "role": {
-                "type": "string",
-                "enum": [
-                  "driver",
-                  "limitation"
-                ]
-              },
-              "summary": {
-                "type": "string",
-                "minLength": 1
-              },
-              "hazards": {
-                "type": "array",
-                "items": {
-                  "type": "string",
-                  "enum": [
-                    "smoke",
-                    "flood",
-                    "heat"
-                  ]
-                },
-                "minItems": 1
-              },
-              "weight": {
-                "type": "number",
-                "minimum": 0,
-                "maximum": 1
-              },
-              "visibility": {
-                "type": "string",
-                "enum": [
-                  "dwelling_safe",
-                  "internal_only"
-                ]
-              },
-              "freshness_band": {
-                "type": "string",
-                "enum": [
-                  "fresh",
-                  "aging",
-                  "stale",
-                  "expired"
-                ]
-              }
-            }
+            "$ref": "#/$defs/evidenceContribution"
           }
         },
         "source_breakdown": {
@@ -239,28 +167,98 @@
               "type": "boolean"
             }
           }
+        },
+        "support_objects_present": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "divergence_summary": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "top_divergence_records": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/divergenceRecord"
+          }
         }
       }
     },
     "hazards": {
+      "$ref": "#/$defs/hazardProbabilities"
+    },
+    "hazard_statuses": {
+      "$ref": "#/$defs/hazardStatuses"
+    },
+    "parcel_priors_applied": {
       "type": "object",
       "required": [
-        "smoke_probability",
-        "flood_probability",
-        "heat_probability"
+        "smoke",
+        "flood",
+        "heat"
       ],
       "additionalProperties": false,
       "properties": {
-        "smoke_probability": {
-          "$ref": "#/$defs/probability"
+        "smoke": {
+          "$ref": "#/$defs/priorDetail"
         },
-        "flood_probability": {
-          "$ref": "#/$defs/probability"
+        "flood": {
+          "$ref": "#/$defs/priorDetail"
         },
-        "heat_probability": {
-          "$ref": "#/$defs/probability"
+        "heat": {
+          "$ref": "#/$defs/priorDetail"
         }
       }
+    },
+    "divergence_records": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/divergenceRecord"
+      }
+    },
+    "public_only_counterfactual": {
+      "$ref": "#/$defs/counterfactual"
+    },
+    "contrastive_explanations": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/contrastiveExplanation"
+      }
+    },
+    "local_value_summary": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "Concise statement of what local node evidence contributed that public context alone could not provide. Null when no local evidence exists or local evidence agrees with public context."
+    },
+    "closed_loop_summary": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "versioning": {
+      "type": "object",
+      "description": "Runtime versioning metadata including API version, runtime lane, and supported lanes."
+    },
+    "action_logs": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "description": "Structured action log entries derived from intervention-event inputs. Present when v1.5 bridge objects are supplied."
+    },
+    "outcome_records": {
+      "type": "array",
+      "items": {
+        "type": "object"
+      },
+      "description": "Structured outcome records derived from verification-outcome inputs. Present when v1.5 bridge objects are supplied."
     },
     "freshness": {
       "type": "object",
@@ -310,6 +308,18 @@
             "type": "string",
             "minLength": 1
           }
+        },
+        "support_object_refs": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "runtime_lane": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Runtime lane that produced this parcel-state (e.g., v0.1, v0.2)."
         }
       }
     }
@@ -328,6 +338,510 @@
       "type": "number",
       "minimum": 0,
       "maximum": 1
+    },
+    "hazardProbabilities": {
+      "type": "object",
+      "required": [
+        "smoke_probability",
+        "flood_probability",
+        "heat_probability"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "smoke_probability": {
+          "$ref": "#/$defs/probability"
+        },
+        "flood_probability": {
+          "$ref": "#/$defs/probability"
+        },
+        "heat_probability": {
+          "$ref": "#/$defs/probability"
+        }
+      }
+    },
+    "hazardStatuses": {
+      "type": "object",
+      "required": [
+        "smoke",
+        "flood",
+        "heat"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "smoke": {
+          "$ref": "#/$defs/status"
+        },
+        "flood": {
+          "$ref": "#/$defs/status"
+        },
+        "heat": {
+          "$ref": "#/$defs/status"
+        }
+      }
+    },
+    "evidenceContribution": {
+      "type": "object",
+      "required": [
+        "contribution_id",
+        "source_class",
+        "source_name",
+        "role",
+        "summary",
+        "hazards",
+        "weight",
+        "visibility"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "contribution_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_class": {
+          "type": "string",
+          "enum": [
+            "local",
+            "shared",
+            "public",
+            "parcel_context",
+            "system"
+          ]
+        },
+        "source_name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "role": {
+          "type": "string",
+          "enum": [
+            "driver",
+            "limitation"
+          ]
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "hazards": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": [
+              "smoke",
+              "flood",
+              "heat"
+            ]
+          },
+          "minItems": 1
+        },
+        "weight": {
+          "$ref": "#/$defs/probability"
+        },
+        "visibility": {
+          "type": "string",
+          "enum": [
+            "dwelling_safe",
+            "internal_only"
+          ]
+        },
+        "freshness_band": {
+          "type": "string",
+          "enum": [
+            "fresh",
+            "aging",
+            "stale",
+            "expired"
+          ]
+        }
+      }
+    },
+    "priorFactor": {
+      "type": "object",
+      "required": [
+        "factor",
+        "value",
+        "effect",
+        "applied_value"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "factor": {
+          "type": "string",
+          "minLength": 1
+        },
+        "value": {},
+        "effect": {
+          "type": "string",
+          "minLength": 1
+        },
+        "applied_value": {
+          "type": "number"
+        }
+      }
+    },
+    "priorDetail": {
+      "type": "object",
+      "required": [
+        "probability",
+        "adjustment",
+        "summary",
+        "factors"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "probability": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "adjustment": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "factors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/priorFactor"
+          }
+        }
+      }
+    },
+    "divergenceRecord": {
+      "type": "object",
+      "required": [
+        "timestamp",
+        "sensor_id",
+        "parameter",
+        "local_value",
+        "regional_value",
+        "regional_source",
+        "correction_applied",
+        "abs_diff",
+        "direction",
+        "magnitude",
+        "persistence_minutes",
+        "persistence_class",
+        "num_concordant_sensors",
+        "confidence"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "sensor_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "parameter": {
+          "type": "string",
+          "minLength": 1
+        },
+        "local_value": {
+          "type": "number"
+        },
+        "regional_value": {
+          "type": "number"
+        },
+        "regional_source": {
+          "type": "string",
+          "minLength": 1
+        },
+        "correction_applied": {
+          "type": "string",
+          "minLength": 1
+        },
+        "abs_diff": {
+          "type": "number",
+          "minimum": 0
+        },
+        "ratio": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "z_score": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0
+        },
+        "direction": {
+          "type": "string",
+          "enum": [
+            "local_elevated",
+            "local_depressed",
+            "concordant"
+          ]
+        },
+        "magnitude": {
+          "type": "string",
+          "enum": [
+            "noise",
+            "low",
+            "moderate",
+            "high",
+            "extreme"
+          ]
+        },
+        "persistence_minutes": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "persistence_class": {
+          "type": "string",
+          "enum": [
+            "transient",
+            "short_term",
+            "sustained",
+            "persistent",
+            "chronic"
+          ]
+        },
+        "aqi_category_local": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "aqi_category_regional": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "aqi_category_diff": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "num_concordant_sensors": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "confidence": {
+          "type": "string",
+          "enum": [
+            "low",
+            "medium",
+            "high"
+          ]
+        }
+      }
+    },
+    "counterfactual": {
+      "type": "object",
+      "required": [
+        "hazards",
+        "hazard_statuses",
+        "confidence"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "hazards": {
+          "$ref": "#/$defs/hazardProbabilities"
+        },
+        "hazard_statuses": {
+          "$ref": "#/$defs/hazardStatuses"
+        },
+        "confidence": {
+          "$ref": "#/$defs/probability"
+        }
+      }
+    },
+    "contrastivePath": {
+      "type": "object",
+      "required": [
+        "conclusion",
+        "hazard_level",
+        "probability",
+        "confidence",
+        "data_sources"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "conclusion": {
+          "$ref": "#/$defs/status"
+        },
+        "hazard_level": {
+          "$ref": "#/$defs/status"
+        },
+        "probability": {
+          "$ref": "#/$defs/probability"
+        },
+        "confidence": {
+          "$ref": "#/$defs/probability"
+        },
+        "data_sources": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "divergenceFactor": {
+      "type": "object",
+      "required": [
+        "factor",
+        "local_value",
+        "public_value",
+        "contribution_delta",
+        "is_novel_signal"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "factor": {
+          "type": "string",
+          "minLength": 1
+        },
+        "local_value": {
+          "type": "number"
+        },
+        "public_value": {
+          "type": "number"
+        },
+        "contribution_delta": {
+          "type": "number"
+        },
+        "is_novel_signal": {
+          "type": "boolean"
+        }
+      }
+    },
+    "contrastBlock": {
+      "type": "object",
+      "required": [
+        "summary",
+        "delta_hazard_level",
+        "delta_probability",
+        "divergence_factors"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "summary": {
+          "type": "string",
+          "minLength": 1
+        },
+        "delta_hazard_level": {
+          "type": "integer"
+        },
+        "delta_probability": {
+          "type": "number"
+        },
+        "divergence_factors": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/divergenceFactor"
+          }
+        }
+      }
+    },
+    "verificationScores": {
+      "type": "object",
+      "required": [
+        "brier_score_fact",
+        "brier_score_foil",
+        "local_data_added_value"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "brier_score_fact": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "brier_score_foil": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "local_data_added_value": {
+          "type": [
+            "boolean",
+            "null"
+          ]
+        }
+      }
+    },
+    "verificationBlock": {
+      "type": "object",
+      "required": [
+        "prediction_window_end",
+        "ground_truth_available",
+        "scores"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "prediction_window_end": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "ground_truth_available": {
+          "type": "boolean"
+        },
+        "scores": {
+          "$ref": "#/$defs/verificationScores"
+        }
+      }
+    },
+    "contrastiveExplanation": {
+      "type": "object",
+      "required": [
+        "explanation_id",
+        "timestamp",
+        "hazard_type",
+        "fact",
+        "foil",
+        "contrast",
+        "verification"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "explanation_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "hazard_type": {
+          "type": "string",
+          "enum": [
+            "smoke",
+            "flood",
+            "heat"
+          ]
+        },
+        "fact": {
+          "$ref": "#/$defs/contrastivePath"
+        },
+        "foil": {
+          "$ref": "#/$defs/contrastivePath"
+        },
+        "contrast": {
+          "$ref": "#/$defs/contrastBlock"
+        },
+        "verification": {
+          "$ref": "#/$defs/verificationBlock"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Mechanically regenerated `bundles/contracts-bundle/` from `v0.1/` via the new generator (oesis-program-specs#TBD — opening separately).

The generator caught real drift the existing CI couldn't see — both bundle copies of the stale schemas were *self-consistent* (stale examples validated against stale schemas), so the schema-against-example CI saw nothing wrong. Only a byte-level compare against v0.1 source surfaces it.

## Drift caught

- `schemas/node-observation.schema.json` — missing `sequence`, `transport`, `notes`, `install_role`, `privacy_mode` fields (added to v0.1 after the hand-maintained bundle was last stamped)
- `schemas/parcel-state.schema.json` — out of sync with v0.1 evolution
- `examples/parcel-context.example.json` + `examples/parcel-state.example.json` — stale payloads
- `manifest.json` — `source_commit` + `generated_at` refreshed to current contracts HEAD

## Going forward

After the generator PR lands in oesis-program-specs, this kind of regeneration is `make repo-split-build-contracts-bundle` — idempotent, dry-run-able, and wired into `repo-split-stage`.

## Test plan

- [ ] CI green (validate workflow re-runs against the regenerated bundle)
- [ ] Bundle examples still validate against bundle schemas (already verified locally via `python3 scripts/validate_examples.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)