### PR TITLE
feat(v1.0): node-observation admissibility facts (G17)

### DIFF
--- a/v1.0/README.md
+++ b/v1.0/README.md
@@ -74,12 +74,13 @@ baseline reference until a real `v1.0` delta is added.
 House-state, intervention-event, and verification-outcome bridge contracts
 belong primarily in `../v1.5/`.
 
-## Planned additions (observation-schema admissibility facts — G17)
+## Observation-schema admissibility facts (G17 — implemented)
 
 Per
 [`architecture/system/calibration-program.md`](https://github.com/lumenaut-llc/oesis-program-specs/blob/main/architecture/system/calibration-program.md)
 §C, the canonical observation schema is extended with facts required to compute
-admissibility decisions. These are planned `v1.0` deltas, not yet landed:
+admissibility decisions. These six fields are now part of the v1.0 lane variant
+of `node-observation`:
 
 - `burn_in_complete: bool` — whether the producing device has cleared its
   §B burn-in window
@@ -94,17 +95,27 @@ admissibility decisions. These are planned `v1.0` deltas, not yet landed:
 - `placement_representativeness_class: enum | null` — A / B / C / D per the
   placement guide
 
+All six fields are **optional** to keep the change forward-compatible — every
+v0.1 observation payload still validates against the v1.0 schema. See
+[`node-observation-schema.md`](node-observation-schema.md) for full field
+semantics, the `location_mode` vs `node_deployment_class` distinction, and
+runtime fallback rules when a field is absent.
+
+Schema: [`schemas/node-observation.schema.json`](schemas/node-observation.schema.json)
+· Example: [`examples/node-observation.example.json`](examples/node-observation.example.json)
+
 Adapter-derived equivalents (`adapter_source_ref`, `adapter_contract_version`,
 `adapter_onboarding_ref`, `adapter_credential_last_verified_at`,
 `adapter_tier`) are planned primarily in `../v1.5/` where adapter surfaces
 land, per
 [`adapter-trust-program.md`](https://github.com/lumenaut-llc/oesis-program-specs/blob/main/architecture/system/adapter-trust-program.md)
-§C.
+§C — tracked as gap G18.
 
 The admissibility **decision** fields (`admissible_to_calibration_dataset`,
 `admissibility_reasons`) do **not** live in this schema — they are computed
-in runtime and attached to the normalized observation only (decision
-2026-04-19: schema carries facts, runtime computes decision).
+in runtime and attached to the normalized observation only (per
+[ADR 0009](https://github.com/lumenaut-llc/oesis-program-specs/blob/main/meta/adr/0009-admissibility-schema-split-facts-vs-decision.md):
+schema carries facts, runtime computes decision).
 
 ## Version boundary (governance)
 

--- a/v1.0/examples/node-observation-mast-lite.example.json
+++ b/v1.0/examples/node-observation-mast-lite.example.json
@@ -24,6 +24,12 @@
     "pressure_hpa": 1012.4,
     "voc_trend_source": "gas_resistance_ohm"
   },
+  "burn_in_complete": true,
+  "node_calibration_session_ref": "calsession:mast-lite-01:2026-04-15T11:00:00Z",
+  "node_deployment_maturity": "v1.0",
+  "node_deployment_class": "sheltered",
+  "protective_fixture_verified_at": "2026-04-15T11:30:00Z",
+  "placement_representativeness_class": "B",
   "health": {
     "uptime_s": 5420,
     "wifi_connected": true,

--- a/v1.0/examples/node-observation.example.json
+++ b/v1.0/examples/node-observation.example.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": "oesis.bench-air.v1",
+  "node_id": "bench-air-01",
+  "observed_at": "2026-04-28T19:45:00Z",
+  "firmware_version": "1.0.0",
+  "location_mode": "indoor",
+  "sensors": {
+    "sht45": {
+      "present": true,
+      "temperature_c": 23.4,
+      "relative_humidity_pct": 41.8
+    },
+    "bme680": {
+      "present": true,
+      "temperature_c": 24.1,
+      "relative_humidity_pct": 40.9,
+      "pressure_hpa": 1012.6,
+      "gas_resistance_ohm": 145230
+    }
+  },
+  "derived": {
+    "temperature_c_primary": 23.4,
+    "relative_humidity_pct_primary": 41.8,
+    "pressure_hpa": 1012.6,
+    "voc_trend_source": "gas_resistance_ohm"
+  },
+  "burn_in_complete": true,
+  "node_calibration_session_ref": "calsession:bench-air-01:2026-04-22T14:30:00Z",
+  "node_deployment_maturity": "v1.0",
+  "node_deployment_class": "indoor",
+  "protective_fixture_verified_at": null,
+  "placement_representativeness_class": "B",
+  "health": {
+    "uptime_s": 1820,
+    "wifi_connected": true,
+    "free_heap_bytes": 214332,
+    "read_failures_total": 0,
+    "last_error": null
+  }
+}

--- a/v1.0/node-observation-schema.md
+++ b/v1.0/node-observation-schema.md
@@ -1,0 +1,64 @@
+# Node Observation Schema (v1.0 lane variant — admissibility facts)
+
+## Purpose
+
+Document the v1.0 lane variant of `node-observation` — adds the six **admissibility-fact** fields that runtime needs to compute the §C admissibility decision per [`calibration-program.md`](https://github.com/lumenaut-llc/oesis-program-specs/blob/main/architecture/system/calibration-program.md).
+
+This is **not** a replacement for the v0.1 baseline schema. It is an additive lane variant per the additive-lane pattern in [`README.md`](README.md). The v0.1 baseline at [`../v0.1/node-observation-schema.md`](../v0.1/node-observation-schema.md) remains unchanged.
+
+## Why this exists (ADR 0009)
+
+Per [ADR 0009](https://github.com/lumenaut-llc/oesis-program-specs/blob/main/meta/adr/0009-admissibility-schema-split-facts-vs-decision.md): **schema carries facts, runtime computes decision**. The facts must be formal schema fields so every consumer sees the same evidence. Before this lane variant, there was no place in the canonical observation to record burn-in state, calibration-session pointers, deployment class, or placement representativeness — so admissibility couldn't be computed deterministically across consumers.
+
+The admissibility *decision* fields (`admissible_to_calibration_dataset`, `admissibility_reasons`) are runtime-computed outputs on the normalized observation. They do **not** appear in this schema.
+
+## What v1.0 adds
+
+The v1.0 schema (`schemas/node-observation.schema.json`) extends v0.1's baseline (12 properties) with six additional fields. All six are **optional** to keep the change forward-compatible — a v0.1-era producer's payload still validates against this schema.
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `burn_in_complete` | boolean | Whether the producing device has cleared the §B burn-in window. Runtime treats absent as `false`. |
+| `node_calibration_session_ref` | string | Opaque pointer to the most recent calibration session record (URN, URL, or repo-relative path; format is implementation-defined). Runtime treats absent as "no calibration on file." |
+| `node_deployment_maturity` | enum | One of `v0.1` / `v1.0` / `v1.5` / `v2.0` per [`deployment-maturity-ladder.md`](https://github.com/lumenaut-llc/oesis-program-specs/blob/main/architecture/system/deployment-maturity-ladder.md). Runtime treats absent as `v0.1`. |
+| `node_deployment_class` | enum | One of `indoor` / `sheltered` / `outdoor` per [`sensor-placement-and-representativeness-guide.md`](https://github.com/lumenaut-llc/oesis-program-specs/blob/main/architecture/system/sensor-placement-and-representativeness-guide.md). |
+| `protective_fixture_verified_at` | timestamp \| null | Last verified thermal-loading (or equivalent) test for the protective fixture, or `null` if no fixture is required. |
+| `placement_representativeness_class` | `A` \| `B` \| `C` \| `D` \| null | Placement representativeness class per the placement guide. |
+
+### `location_mode` vs `node_deployment_class` — not the same field
+
+These are intentionally separate:
+
+- **`location_mode`** (in v0.1 baseline) is a *producer-side intent declaration* — what the firmware was told about its placement at install time.
+- **`node_deployment_class`** (new in v1.0) is a *verified install attribute* — what the deployment audit confirmed and what admissibility logic should use.
+
+In well-installed nodes the two will agree. Disagreement is a real signal: either the firmware was misconfigured or the install differs from intent. Runtime can flag this as an admissibility reason without re-reading the producer's own `location_mode`.
+
+## Versioning posture
+
+- **`schema_version` is unchanged** at `oesis.bench-air.v1`. This is intentional — the v0.1 and v1.0 schemas are versioning the *contract surface*, not the *wire format*. A producer stamping `oesis.bench-air.v1` and including the new fields is still emitting a valid bench-air observation; older consumers ignore unknown fields.
+- **Backward compatibility:** every v0.1 example validates against this schema (the new fields are optional).
+- **Forward compatibility:** consumers that read this lane should treat any of the six new fields as "may be absent" and apply the runtime fallback rules in calibration-program §C.
+
+## Adapter-derived parallel (not in this schema)
+
+For Tier 1 / Tier 2 adapter sources, the parallel adapter-trust-program §C facts (`adapter_source_ref`, `adapter_contract_version`, `adapter_onboarding_ref`, `adapter_credential_last_verified_at`, `adapter_tier`) land in the v1.5 lane variant. See [`../v1.5/`](../v1.5/) (tracked as gap G18). Runtime branches on `adapter_tier` — if absent or `tier_3_direct`, calibration-program §C applies (this schema's facts); otherwise adapter-trust-program §C applies.
+
+## Variant examples
+
+The v1.0 lane also contains two pre-existing variant examples that share this schema's superset shape:
+
+- `examples/node-observation-mast-lite.example.json` — bench-air with mast-lite radiation shield (still `oesis.bench-air.v1`)
+- `examples/node-observation-flood.example.json` — flood-node payload (uses `oesis.flood-node.v1` — different schema; see `flood-observation.schema.json` for that lane's contract)
+
+The mast-lite variant should populate the admissibility facts on the same v1.0 cadence as the canonical example. Flood-observation has its own admissibility surface tracked separately.
+
+## Related
+
+- [ADR 0009 — schema-carries-facts decision](https://github.com/lumenaut-llc/oesis-program-specs/blob/main/meta/adr/0009-admissibility-schema-split-facts-vs-decision.md)
+- [Calibration program §C](https://github.com/lumenaut-llc/oesis-program-specs/blob/main/architecture/system/calibration-program.md)
+- [Adapter-trust program §C](https://github.com/lumenaut-llc/oesis-program-specs/blob/main/architecture/system/adapter-trust-program.md)
+- [`../v0.1/node-observation-schema.md`](../v0.1/node-observation-schema.md) — baseline (no admissibility facts)
+- [`schema-migration-v0.1-to-v1.0.md`](schema-migration-v0.1-to-v1.0.md) — migration notes for runtime
+- `schemas/node-observation.schema.json` — v1.0 schema JSON
+- `examples/node-observation.example.json` — v1.0 canonical example with all six fields populated

--- a/v1.0/schemas/node-observation.schema.json
+++ b/v1.0/schemas/node-observation.schema.json
@@ -1,0 +1,216 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://lumenaut-llc.github.io/oesis-program-specs/contracts/v1.0/schemas/node-observation.schema.json",
+  "title": "OESIS Node Observation v1.0 (admissibility facts)",
+  "description": "v1.0 lane variant of node-observation that extends the v0.1 baseline with the six admissibility-fact fields required by calibration-program §C. Per ADR 0009 (schema carries facts, runtime computes decision), these are factual fields only — the admissibility decision is computed in runtime and attached to normalized observations, never to the canonical observation.",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "node_id",
+    "observed_at",
+    "firmware_version",
+    "location_mode",
+    "sensors",
+    "health"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "const": "oesis.bench-air.v1"
+    },
+    "node_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "observed_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "firmware_version": {
+      "type": "string",
+      "minLength": 1
+    },
+    "location_mode": {
+      "type": "string",
+      "enum": [
+        "indoor",
+        "sheltered",
+        "outdoor"
+      ]
+    },
+    "sensors": {
+      "type": "object",
+      "required": [
+        "sht45",
+        "bme680"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "sht45": {
+          "$ref": "#/$defs/sht45Reading"
+        },
+        "bme680": {
+          "$ref": "#/$defs/bme680Reading"
+        }
+      }
+    },
+    "derived": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "temperature_c_primary": {
+          "type": "number"
+        },
+        "relative_humidity_pct_primary": {
+          "type": "number"
+        },
+        "pressure_hpa": {
+          "type": "number"
+        },
+        "voc_trend_source": {
+          "type": "string"
+        }
+      }
+    },
+    "sequence": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "transport": {
+      "type": "object"
+    },
+    "notes": {
+      "type": "string"
+    },
+    "install_role": {
+      "type": "string",
+      "minLength": 1
+    },
+    "privacy_mode": {
+      "type": "string",
+      "enum": [
+        "normal",
+        "derived_only",
+        "bounded_internal"
+      ]
+    },
+    "burn_in_complete": {
+      "type": "boolean",
+      "description": "Whether the producing device has cleared the §B burn-in window per calibration-program.md. Optional in v1.0 to remain forward-compatible with v0.1 producers; runtime treats absent as false."
+    },
+    "node_calibration_session_ref": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Opaque pointer to the most recent calibration session record for this node. Format is implementation-defined (URN, URL, or repo-relative path). Optional; runtime treats absent as 'no calibration on file'."
+    },
+    "node_deployment_maturity": {
+      "type": "string",
+      "enum": ["v0.1", "v1.0", "v1.5", "v2.0"],
+      "description": "Deployment maturity per deployment-maturity-ladder.md. Optional in v1.0; runtime treats absent as v0.1 (lowest)."
+    },
+    "node_deployment_class": {
+      "type": "string",
+      "enum": ["indoor", "sheltered", "outdoor"],
+      "description": "Deployment class per sensor-placement-and-representativeness-guide.md. Distinct from location_mode (which is a producer-side intent declaration); deployment_class is a verified install attribute. Optional in v1.0."
+    },
+    "protective_fixture_verified_at": {
+      "type": ["string", "null"],
+      "format": "date-time",
+      "description": "Last verified thermal-loading (or equivalent) test for the protective fixture, or null if no fixture is required for this deployment_class. Optional in v1.0; runtime treats absent as null."
+    },
+    "placement_representativeness_class": {
+      "type": ["string", "null"],
+      "enum": ["A", "B", "C", "D", null],
+      "description": "Placement representativeness class A/B/C/D per sensor-placement-and-representativeness-guide.md, or null if not yet assessed. Optional in v1.0."
+    },
+    "health": {
+      "type": "object",
+      "required": [
+        "uptime_s",
+        "wifi_connected",
+        "free_heap_bytes",
+        "read_failures_total",
+        "last_error"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "uptime_s": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "wifi_connected": {
+          "type": "boolean"
+        },
+        "free_heap_bytes": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "read_failures_total": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "last_error": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    }
+  },
+  "$defs": {
+    "sht45Reading": {
+      "type": "object",
+      "required": [
+        "present",
+        "temperature_c",
+        "relative_humidity_pct"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "present": {
+          "type": "boolean"
+        },
+        "temperature_c": {
+          "type": "number"
+        },
+        "relative_humidity_pct": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        }
+      }
+    },
+    "bme680Reading": {
+      "type": "object",
+      "required": [
+        "present",
+        "temperature_c",
+        "relative_humidity_pct",
+        "pressure_hpa",
+        "gas_resistance_ohm"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "present": {
+          "type": "boolean"
+        },
+        "temperature_c": {
+          "type": "number"
+        },
+        "relative_humidity_pct": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "pressure_hpa": {
+          "type": "number"
+        },
+        "gas_resistance_ohm": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the v1.0 lane variant of `node-observation` with the six admissibility-fact fields required by calibration-program §C, per [ADR 0009](https://github.com/lumenaut-llc/oesis-program-specs/blob/main/meta/adr/0009-admissibility-schema-split-facts-vs-decision.md) (schema carries facts, runtime computes decision).

Closes #2. Unblocks `oesis-runtime#G15` (admissibility-decision computation).

## Six fields added (all optional)

| Field | Type | Purpose |
| --- | --- | --- |
| `burn_in_complete` | bool | §B burn-in window cleared |
| `node_calibration_session_ref` | string | Pointer to most recent calibration session |
| `node_deployment_maturity` | enum | `v0.1` / `v1.0` / `v1.5` / `v2.0` per deployment-maturity-ladder |
| `node_deployment_class` | enum | `indoor` / `sheltered` / `outdoor` per placement guide |
| `protective_fixture_verified_at` | timestamp \| null | Last fixture verification |
| `placement_representativeness_class` | A/B/C/D \| null | Per placement guide |

## Design

- **v0.1 baseline unchanged.** The lane model is doctrine — v0.1 stays frozen. New fields live only in `v1.0/schemas/node-observation.schema.json`.
- **All fields optional.** Every v0.1 payload still validates against the v1.0 schema. Forward-compatible.
- **`schema_version` unchanged** at `oesis.bench-air.v1`. The lane number versions the contract surface, not the wire format.
- **Decision fields stay out of schema.** `admissible_to_calibration_dataset` and `admissibility_reasons` are runtime outputs on normalized observations — never on canonical observations.
- **`location_mode` vs `node_deployment_class`.** Documented as intentionally distinct: producer-side intent declaration vs verified install attribute. Disagreement is a real signal runtime can flag.

## Variant examples

Updated `node-observation-mast-lite.example.json` to populate the new facts at v1.0 cadence. `node-observation-flood.example.json` is a separate schema (`oesis.flood-node.v1`) and is out of scope here.

## Paired PRs

- **oesis-runtime#TBD** — mirrors the new examples to `oesis/assets/v1.0/examples/`. Runtime's existing `validate_node_observation` already accepts these payloads (verified by `check_runtime_compat.py`).

## Verification

```
python3 scripts/validate_examples.py            # all examples validate
python3 scripts/check_runtime_compat.py --runtime ../oesis-runtime   # runtime accepts new examples
```

Both pass locally.

## Test plan

- [ ] Validate JSON schemas CI green
- [ ] Examples-against-schemas CI green
- [ ] Runtime-compat CI green (the gate added in #9)
- [ ] Cross-repo sync clean once paired runtime PR merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)