### PR TITLE
feat(v1.5): adapter-trust facts on source-provenance-record (G18 schema-side)

### DIFF
--- a/v1.5/examples/source-provenance-record.example.json
+++ b/v1.5/examples/source-provenance-record.example.json
@@ -18,7 +18,12 @@
         "intervention_context",
         "verification_context"
       ],
-      "raw_ref": "obs_hvac_ct_0007"
+      "raw_ref": "obs_hvac_ct_0007",
+      "adapter_source_ref": "adapter:ct_clamp_hvac/v1.0/source-authority.md",
+      "adapter_contract_version": "ct-clamp-hvac.v1.2",
+      "adapter_onboarding_ref": "onboarding:parcel_demo_001:ct_clamp_hvac:2026-04-01T15:00:00Z",
+      "adapter_credential_last_verified_at": "2026-04-14T08:00:00Z",
+      "adapter_tier": "tier_2_adapter"
     },
     {
       "signal_key": "outdoor_air_intake",

--- a/v1.5/schemas/source-provenance-record.schema.json
+++ b/v1.5/schemas/source-provenance-record.schema.json
@@ -95,6 +95,31 @@
           "raw_ref": {
             "type": "string",
             "minLength": 1
+          },
+          "adapter_source_ref": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Pointer to the source authority file under adapter-trust-program §A (URN, URL, or repo-relative path). Required when source_kind == 'adapter_derived'."
+          },
+          "adapter_contract_version": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Version string the reading was produced against (e.g. an API version or contract revision). Required when source_kind == 'adapter_derived'."
+          },
+          "adapter_onboarding_ref": {
+            "type": "string",
+            "minLength": 1,
+            "description": "Pointer to the parcel's initial verification record for this adapter. Required when source_kind == 'adapter_derived'."
+          },
+          "adapter_credential_last_verified_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp of the most recent credential / contract-version verification for this adapter source. Required when source_kind == 'adapter_derived'."
+          },
+          "adapter_tier": {
+            "type": "string",
+            "enum": ["tier_1_passive", "tier_2_adapter", "tier_3_direct"],
+            "description": "Adapter tier per node-taxonomy.md. Required when source_kind == 'adapter_derived'. Note: tier_3_direct on an adapter_derived record is unusual — it indicates a direct-measurement source routed through an adapter wrapper for uniform handling."
           }
         },
         "allOf": [
@@ -113,6 +138,18 @@
           {
             "if": { "properties": { "value_type": { "const": "null" } } },
             "then": { "required": ["null_value"] }
+          },
+          {
+            "if": { "properties": { "source_kind": { "const": "adapter_derived" } } },
+            "then": {
+              "required": [
+                "adapter_source_ref",
+                "adapter_contract_version",
+                "adapter_onboarding_ref",
+                "adapter_credential_last_verified_at",
+                "adapter_tier"
+              ]
+            }
           }
         ]
       }

--- a/v1.5/source-provenance-record-schema.md
+++ b/v1.5/source-provenance-record-schema.md
@@ -29,6 +29,27 @@ Per-record minimum:
 - `ttl_seconds`
 - `stale`
 
+## Adapter-trust facts (G18 — when `source_kind == "adapter_derived"`)
+
+Per [ADR 0009](https://github.com/lumenaut-llc/oesis-program-specs/blob/main/meta/adr/0009-admissibility-schema-split-facts-vs-decision.md) and [`adapter-trust-program.md`](https://github.com/lumenaut-llc/oesis-program-specs/blob/main/architecture/system/adapter-trust-program.md) §C, every record with `source_kind == "adapter_derived"` carries five adapter-trust facts that runtime needs to compute the §C admissibility decision:
+
+| Field | Type | Purpose |
+| --- | --- | --- |
+| `adapter_source_ref` | string | Pointer to the source authority file under adapter-trust-program §A |
+| `adapter_contract_version` | string | Version string the reading was produced against |
+| `adapter_onboarding_ref` | string | Pointer to the parcel's initial verification record for this adapter |
+| `adapter_credential_last_verified_at` | timestamp | Most recent credential / contract-version verification |
+| `adapter_tier` | enum | One of `tier_1_passive` / `tier_2_adapter` / `tier_3_direct` per node-taxonomy.md |
+
+These are **conditionally required** — the schema enforces their presence only when `source_kind == "adapter_derived"`. Records with `source_kind` of `direct_measurement`, `inferred`, or `manual_entry` neither require nor populate them.
+
+This is the v1.5 parallel to G17's calibration-program §C facts on v1.0 `node-observation`. Runtime branches on `adapter_tier`:
+
+- absent or `tier_3_direct` → calibration-program §C rules apply (use the v1.0 node-observation facts on the producing node)
+- `tier_1_passive` or `tier_2_adapter` → adapter-trust-program §C rules apply (use these adapter facts)
+
+The admissibility **decision** fields (`admissible_to_calibration_dataset`, `admissibility_reasons`) do NOT live in this schema — they are runtime outputs on normalized observations only.
+
 ## Guardrails
 
 - Keep this object private by default.
@@ -38,6 +59,9 @@ Per-record minimum:
 
 ## Related
 
+- [ADR 0009 — schema-carries-facts decision](https://github.com/lumenaut-llc/oesis-program-specs/blob/main/meta/adr/0009-admissibility-schema-split-facts-vs-decision.md)
+- [Adapter-trust program §C](https://github.com/lumenaut-llc/oesis-program-specs/blob/main/architecture/system/adapter-trust-program.md)
+- [`../v1.0/node-observation-schema.md`](../v1.0/node-observation-schema.md) — calibration-program §C parallel (G17)
 - `equipment-state-observation-schema.md`
 - `verification-outcome-schema.md`
-- `../../evidence-mode-and-observability.md`
+- `../v0.1/evidence-mode-and-observability.md`


### PR DESCRIPTION
## Summary

Adds the five adapter-trust §C facts to v1.5 \`source-provenance-record\` so runtime can compute admissibility for \`adapter_derived\` records, per [ADR 0009](https://github.com/lumenaut-llc/oesis-program-specs/blob/main/meta/adr/0009-admissibility-schema-split-facts-vs-decision.md).

This closes the **schema-side scope** of G18. The broader G18 program work (adapter spec docs, procedures, onboarding records under \`oesis-builds/specs/adapters/\`) remains separately tracked in [oesis-hardware#6](https://github.com/lumenaut-llc/oesis-hardware/issues/6).

## Five fields added

| Field | Type | Purpose |
| --- | --- | --- |
| \`adapter_source_ref\` | string | Pointer to source authority file (§A) |
| \`adapter_contract_version\` | string | API/contract version reading was produced against |
| \`adapter_onboarding_ref\` | string | Pointer to parcel's initial verification record |
| \`adapter_credential_last_verified_at\` | timestamp | Most recent credential verification |
| \`adapter_tier\` | enum | \`tier_1_passive\` / \`tier_2_adapter\` / \`tier_3_direct\` |

## Design

- **Conditionally required.** Schema enforces presence only when \`source_kind == "adapter_derived"\` via an \`allOf\` if/then rule. Records with other \`source_kind\` values neither require nor populate them.
- **v0.1 baseline unchanged.** Lane model is doctrine — these facts live exclusively in v1.5.
- **Decision fields stay out of schema.** \`admissible_to_calibration_dataset\` and \`admissibility_reasons\` are runtime outputs on normalized observations only.
- **Parallel to G17.** Runtime branches on \`adapter_tier\`: absent or \`tier_3_direct\` → calibration-program §C (the v1.0 node-observation facts from G17); \`tier_1_passive\` or \`tier_2_adapter\` → adapter-trust-program §C (these adapter facts).

## Verification

\`\`\`
python3 scripts/validate_examples.py            # all examples validate
python3 scripts/check_runtime_compat.py --runtime ../oesis-runtime   # runtime accepts new example
\`\`\`

Both pass locally.

## Paired PR

- **oesis-runtime#TBD** — fixture mirror

## Test plan

- [ ] All 4 contracts CI checks green
- [ ] Cross-repo sync clean once paired runtime PR merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)